### PR TITLE
Handle streams without bitrate

### DIFF
--- a/modules/media_server.py
+++ b/modules/media_server.py
@@ -254,7 +254,7 @@ class JellyfinServer(BaseServer):
                     
                     bandwidth = 0
                     for stream in session["NowPlayingItem"]["MediaStreams"]:
-                        bandwidth += int(stream["BitRate"])
+                        bandwidth += int(stream.get("BitRate", 0))
                 
                 else:
                     bandwidth = int(session["TranscodingInfo"]["Bitrate"])


### PR DESCRIPTION
Some streams (like subtitles) don't have a `BitRate` field. This makes speedrr crash:
```
[2024-12-03 22:37:43,207] [ERROR] <jellyfin|http://jellyfin:8096> Error getting bandwidth:
Traceback (most recent call last):
  File "/home/modules/media_server.py", line 145, in run
    bandwidth = int(self.get_bandwidth() * self._server_config.bandwidth_multiplier)
  File "/home/modules/media_server.py", line 257, in get_bandwidth
    bandwidth += int(stream["BitRate"])
KeyError: 'BitRate'
 (media_server.py:147)
```

With this change those streams without bitrates are gracefully ignored