### PR TITLE
Implement ignore list configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -100,12 +100,21 @@ modules:
       # The interval in seconds to update the Plex stream data
       update_interval: 5
 
-      # Checks if a stream is local, and if it is, it will ignore it from calculations
-      ignore_local_streams: true
-      
-      # After a stream has been paused for this amount of seconds, it will be ignored from calculations
-      # Note: To disable this feature, set to -1.
-      ignore_paused_after: 300
+      # Checks if a stream matches any of the given conditions, and if it does, it will ignore it from calculations
+      ignore_streams:
+        
+        # Whether to ignore all local streams (i.e. streams from IP addresses considered private)
+        local: true
+        
+        # Optional list of IP networks to ignore
+        # Each network should consist of an IP address and an optional netmask, separated by a slash
+        # If no mask is provided, it's considered to be /32
+        # Example: 192.168.0.0/24, 192.168.1.123
+        ip_networks:
+        
+        # After a stream has been paused for this amount of seconds, it will be ignored from calculations
+        # Note: To disable this feature, set to -1.
+        paused_after: 300
   
 
   # Changes the upload/download speed based on the time of day, and what day of the week

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -12,14 +12,19 @@ class ClientConfig(YAMLWizard):
     https_verify: bool
 
 @dataclass(frozen=True)
+class IgnoreStreamConfig(YAMLWizard):
+    local: bool
+    ip_networks: Optional[tuple[str, ...]]
+    paused_after: int
+
+@dataclass(frozen=True)
 class MediaServerConfig(YAMLWizard):
     type: Literal['plex', 'tautulli', 'jellyfin', 'emby']
     url: str
     https_verify: bool
     bandwidth_multiplier: float
     update_interval: int
-    ignore_local_streams: bool
-    ignore_paused_after: int
+    ignore_streams: IgnoreStreamConfig
     token: Optional[str] = None
     api_key: Optional[str] = None
 
@@ -30,7 +35,7 @@ class MediaServerConfig(YAMLWizard):
 class ScheduleConfig(YAMLWizard):
     start: str
     end: str
-    days: tuple[Literal['all', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']]
+    days: tuple[Literal['all', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'], ...]
     upload: Union[int, str]
     download: Union[int, str]
 


### PR DESCRIPTION
Adds  `ip_networks` as a config option for a list of IP networks to classify as local. This is useful in media server implementations where internet streams come through a local IP address, as is the case when using a VPN to connect to a home network.

I tested this using a Jellyfin server, and it should also work on Emby. Plex, however, I am unsure about if this would make any difference, as they seem to give only a simple 'lan' or 'wan'.

I also only tested this with IPv4 addresses, so if anyone is willing to test this with IPv6 addresses, that would be appreciated. IPv6 should theoretically work though since it's supported by the Python `ipaddress` module.