### PR TITLE
Add Transmission support

### DIFF
--- a/clients/transmission.py
+++ b/clients/transmission.py
@@ -11,7 +11,7 @@ from helpers.config import SpeedrrConfig, ClientConfig
 from helpers.log_loader import logger
 from helpers.bit_convert import bit_conv
 
-class transmissionClient:
+class TransmissionClient:
     def __init__(self, config: SpeedrrConfig, config_client: ClientConfig) -> None:
         self._client_config = config_client
         self._config = config

--- a/clients/transmission.py
+++ b/clients/transmission.py
@@ -16,6 +16,8 @@ class TransmissionClient:
         self._client_config = config_client
         self._config = config
 
+
+        # Gets hostname, port, and path from url and checks if values are sensible
         u = urllib.parse.urlparse(config_client.url)
 
         protocol = u.scheme
@@ -28,6 +30,7 @@ class TransmissionClient:
         
         if u.hostname is None:
             raise ValueError(f"<trans|{self._client_config.url}> Missing hostname")
+
 
         logger.debug(f"<trans|{self._client_config.url}> Connecting to Transmission at {config_client.url}")
 

--- a/clients/transmission.py
+++ b/clients/transmission.py
@@ -1,6 +1,49 @@
 import transmission_rpc
-from typing import Union
+from transmission_rpc.error import (
+    TransmissionAuthError,
+    TransmissionConnectError,
+    TransmissionTimeoutError,
+)
+from typing import Union, Literal
 
 from helpers.config import SpeedrrConfig, ClientConfig
 from helpers.log_loader import logger
 from helpers.bit_convert import bit_conv
+
+class transmissionClient:
+    def __init__(self, config: SpeedrrConfig, config_client: ClientConfig) -> None:
+        # Get protocol and host adress from the url
+        if "http" in config_client.url:
+            protocol, url_adress = config_client.url.split("://")
+            if protocol not in ("http", "https"):
+                raise ValueError(f"<trans|{self._client_config.url}> Url protocol has to be http or https, not {protocol}")
+            url_protocol: Literal['http', 'https'] = protocol
+        else:
+            url_protocol = "http"
+            url_adress = config_client.url
+
+        self._client_config = config_client
+        self._config = config
+
+        logger.debug(f"<trans|{self._client_config.url}> Connecting to Transmission at {config_client.url}")
+
+        try:
+            self._client = transmission_rpc.Client(
+                protocol = url_protocol,
+                username = config_client.url,
+                password = config_client.password,
+                host = url_adress,
+                port = 9091, # TODO allow custom port
+                path = '/transmission/rpc', # TODO Check if this has to be customisable
+            )
+        
+        except TransmissionTimeoutError:
+            raise Exception(f"<trans|{self._client_config.url}> Connection to Transmission timed out")
+        
+        except TransmissionAuthError:
+            raise Exception(f"<trans|{self._client_config.url}> Failed to login to Transmission, check your credentials")
+
+        except TransmissionConnectError:
+            raise Exception(f"<trans|{self._client_config.url}> Failed to connect to Transmission, check your url")
+
+        logger.debug(f"<trans|{self._client_config.url}> Connected to Transmission")

--- a/clients/transmission.py
+++ b/clients/transmission.py
@@ -55,3 +55,19 @@ class transmissionClient:
 
         sessionStats = self._client.session_stats()
         return sessionStats.active_torrent_count
+
+    def set_upload_speed(self, speed: Union[int, float]) -> None:
+        "Set the upload speed limit for the client, in config units."
+
+        logger.debug(f"<trans|{self._client_config.url}> Setting upload speed to {speed}{self._config.units}")
+
+        speed_limit_up = max(1, int(bit_conv(speed, self._config.units, 'KB')))
+        self._client.set_session(speed_limit_up=speed_limit_up)
+
+    def set_download_speed(self, speed: Union[int, float]) -> None:
+        "Set the download speed limit for the client, in config units."
+
+        logger.debug(f"<trans|{self._client_config.url}> Setting dowload speed to {speed}{self._config.units}")
+
+        speed_limit_down = max(1, int(bit_conv(speed, self._config.units, "KB")))
+        self._client.set_session(speed_limit_down=speed_limit_down)

--- a/clients/transmission.py
+++ b/clients/transmission.py
@@ -1,0 +1,6 @@
+import transmission_rpc
+from typing import Union
+
+from helpers.config import SpeedrrConfig, ClientConfig
+from helpers.log_loader import logger
+from helpers.bit_convert import bit_conv

--- a/clients/transmission.py
+++ b/clients/transmission.py
@@ -47,3 +47,11 @@ class transmissionClient:
             raise Exception(f"<trans|{self._client_config.url}> Failed to connect to Transmission, check your url")
 
         logger.debug(f"<trans|{self._client_config.url}> Connected to Transmission")
+
+    def get_active_torrent_count(self) -> int:
+        "Get the number of torrents that are currently downloading or uploading."
+
+        logger.debug(f"<trans|{self._client_config.url}> Getting active torrent count")
+
+        sessionStats = self._client.session_stats()
+        return sessionStats.active_torrent_count

--- a/clients/transmission.py
+++ b/clients/transmission.py
@@ -4,7 +4,7 @@ from transmission_rpc.error import (
     TransmissionConnectError,
     TransmissionTimeoutError,
 )
-from typing import Union, Literal
+from typing import Union
 import urllib.parse
 
 from helpers.config import SpeedrrConfig, ClientConfig
@@ -37,8 +37,8 @@ class TransmissionClient:
                 username = config_client.username,
                 password = config_client.password,
                 host = u.hostname,
-                port = u.port or default_port, # TODO allow custom port
-                path = u.path or "/transmission/rpc", # TODO Check if this has to be customisable
+                port = u.port or default_port,
+                path = u.path or "/transmission/rpc",
             )
         
         except TransmissionTimeoutError:

--- a/config.yaml
+++ b/config.yaml
@@ -48,7 +48,7 @@ max_download: 100
 clients:
 
   # The type of torrent client
-  # Options: qbittorrent
+  # Options: qbittorrent, transmission
   - type: qbittorrent
 
     # The URL to your torrent client
@@ -60,6 +60,7 @@ clients:
 
     # Whether to verify the SSL certificate of the torrent client
     # If you are unsure what this means, leave it as is.
+    # Only has an influence on qbittorrent
     https_verify: true
 
 

--- a/main.py
+++ b/main.py
@@ -31,13 +31,13 @@ if __name__ == '__main__':
     update_event = threading.Event()
     
 
-    clients: List[Union[qbittorrent.qBittorrentClient, transmission.transmissionClient]] = []
+    clients: List[Union[qbittorrent.qBittorrentClient, transmission.TransmissionClient]] = []
     for client in cfg.clients:
         if client.type == "qbittorrent":
             torrent_client = qbittorrent.qBittorrentClient(cfg, client)
 
         elif client.type == "transmission":
-            torrent_client = transmission.transmissionClient(cfg, client)
+            torrent_client = transmission.TransmissionClient(cfg, client)
 
         else:
             logger.critical(f"Unknown client type in config: {client.type}")

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import traceback
 
 from helpers.log_loader import logger
 from helpers import arguments, config, log_loader
-from clients import qbittorrent
+from clients import qbittorrent, transmission
 from modules import media_server, schedule
 
 
@@ -31,11 +31,14 @@ if __name__ == '__main__':
     update_event = threading.Event()
     
 
-    clients: List[Union[qbittorrent.qBittorrentClient]] = []
+    clients: List[Union[qbittorrent.qBittorrentClient, transmission.transmissionClient]] = []
     for client in cfg.clients:
         if client.type == "qbittorrent":
             torrent_client = qbittorrent.qBittorrentClient(cfg, client)
-        
+
+        elif client.type == "transmission":
+            torrent_client = transmission.transmissionClient(cfg, client)
+
         else:
             logger.critical(f"Unknown client type in config: {client.type}")
             exit()

--- a/modules/media_server.py
+++ b/modules/media_server.py
@@ -252,7 +252,7 @@ class JellyfinServer(BaseServer):
             if session.get("NowPlayingItem"): # Ignore sessions that aren't playing anything
                 session_ids.append(session["Id"])
 
-                if session["PlayState"]["PlayMethod"] == "DirectPlay":
+                if session["PlayState"]["PlayMethod"] in ["DirectPlay", "DirectStream"]:
                     logger.debug(f"{self._logger_prefix} {session['Id']} is direct play, calculating estimated bandwidth from MediaStreams")
                     
                     bandwidth = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 dataclass_wizard
 PyYAML
 qbittorrent-api
+transmission-rpc
 httpx
 colorama


### PR DESCRIPTION
Hi!

I decided to add support for Transmission clients.

I added a transmission.py file to the clients directory and updated main.py to integrate this new client. To communicate with the Transmission API, I used the [transmission-rpc](https://github.com/Trim21/transmission-rpc) library. I also reused their URL parsing logic from their __init__.py file.

Additionally, I updated media_server.py to check for "DirectStream" alongside "DirectPlay" when determining if the stream is being transcoded for Jellyfin. This is because the Streamyfin app reports "DirectStream" instead of "DirectPlay" for direct streams.

Finally, I added Transmission to the supported clients comment in the default config.yaml file.

This is my first contribution to open source, so I hope I did everything right here. Thank you for considering my pull request!