### PR TITLE
Option to use shares for speed division over multiple clients instead of torrent count

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,7 +43,7 @@ min_download: 10
 # This should be around 70-100% of your total download speed.
 max_download: 100
 
-manual_speed_algorithm_share: true # Set speed based on manually configured shares instead of using number of active torrents
+manual_speed_algorithm_share: false # Set speed based on manually configured shares instead of using number of active torrents
 
 # The torrent clients to be used by Speedrr
 # Note: If you have multiple clients, Speedrr will split the upload speed between them, based on the number of seeding+downloading torrents.

--- a/config.yaml
+++ b/config.yaml
@@ -43,7 +43,7 @@ min_download: 10
 # This should be around 70-100% of your total download speed.
 max_download: 100
 
-manual_speed_algorithm_share: true # Set speed based on manually set shares instead of using number of active torrents
+manual_speed_algorithm_share: true # Set speed based on manually configured shares instead of using number of active torrents
 
 # The torrent clients to be used by Speedrr
 # Note: If you have multiple clients, Speedrr will split the upload speed between them, based on the number of seeding+downloading torrents.
@@ -59,7 +59,7 @@ clients:
     username: <username>
     password: <password>
 
-    # Number of shares of total upload and download speed. Ignored if manual_speed_algorithm_share is set to true
+    # Number of shares of total upload and download speed. Ignored if manual_speed_algorithm_share is set to false
     download_shares: 1
     upload_shares: 1
 

--- a/config.yaml
+++ b/config.yaml
@@ -43,10 +43,11 @@ min_download: 10
 # This should be around 70-100% of your total download speed.
 max_download: 100
 
+manual_speed_algorithm_share: true # Set speed based on manually set shares instead of using number of active torrents
+
 # The torrent clients to be used by Speedrr
 # Note: If you have multiple clients, Speedrr will split the upload speed between them, based on the number of seeding+downloading torrents.
 clients:
-
   # The type of torrent client
   # Options: qbittorrent, transmission
   - type: qbittorrent
@@ -57,6 +58,10 @@ clients:
     # The username and password to access your torrent client
     username: <username>
     password: <password>
+
+    # Number of shares of total upload and download speed. Ignored if manual_speed_algorithm_share is set to true
+    download_shares: 1
+    upload_shares: 1
 
     # Whether to verify the SSL certificate of the torrent client
     # If you are unsure what this means, leave it as is.

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -10,6 +10,9 @@ class ClientConfig(YAMLWizard):
     username: str
     password: str
     https_verify: bool
+    download_shares: int = 1
+    upload_shares: int = 1
+
 
 @dataclass(frozen=True)
 class IgnoreStreamConfig(YAMLWizard):
@@ -82,7 +85,7 @@ class SpeedrrConfig(YAMLWizard):
     max_download: int
     clients: List[ClientConfig]
     modules: ModulesConfig
-
+    manual_speed_algorithm_share: Optional[bool] = False
 
 def load_config(config_file: str) -> SpeedrrConfig:
     config = SpeedrrConfig.from_yaml_file(config_file)

--- a/main.py
+++ b/main.py
@@ -115,8 +115,8 @@ if __name__ == '__main__':
             for torrent_client, active_torrent_count in client_active_torrent_dict.items():
                 # If there are no active torrents, set the upload speed to the new speed
                 if cfg.manual_speed_algorithm_share:
-                    effective_upload_speed = (torrent_client._client_config.download_shares / sum_client_upload_shares * new_upload_speed) if active_torrent_count > 0 else new_upload_speed
-                    effective_download_speed = (torrent_client._client_config.upload_shares / sum_client_download_shares * new_download_speed) if active_torrent_count > 0 else new_download_speed
+                    effective_upload_speed = (torrent_client._client_config.download_shares / sum_client_upload_shares * new_upload_speed)
+                    effective_download_speed = (torrent_client._client_config.upload_shares / sum_client_download_shares * new_download_speed)
                 else: 
                     effective_upload_speed = (active_torrent_count / sum_active_torrents * new_upload_speed) if active_torrent_count > 0 else new_upload_speed
                     effective_download_speed = (active_torrent_count / sum_active_torrents * new_download_speed) if active_torrent_count > 0 else new_download_speed

--- a/main.py
+++ b/main.py
@@ -44,7 +44,9 @@ if __name__ == '__main__':
             exit()
 
         clients.append(torrent_client)
-
+        
+    sum_client_upload_shares = sum(client.upload_shares for client in cfg.clients)
+    sum_client_download_shares = sum(client.download_shares for client in cfg.clients)
 
     modules: List[Union[media_server.MediaServerModule, schedule.ScheduleModule]] = []
     if cfg.modules.media_servers:
@@ -109,12 +111,15 @@ if __name__ == '__main__':
             }
 
             sum_active_torrents = sum(client_active_torrent_dict.values())
-
+            
             for torrent_client, active_torrent_count in client_active_torrent_dict.items():
                 # If there are no active torrents, set the upload speed to the new speed
-                effective_upload_speed = (active_torrent_count / sum_active_torrents * new_upload_speed) if active_torrent_count > 0 else new_upload_speed
-                effective_download_speed = (active_torrent_count / sum_active_torrents * new_download_speed) if active_torrent_count > 0 else new_download_speed
-                
+                if cfg.manual_speed_algorithm_share:
+                    effective_upload_speed = (torrent_client._client_config.download_shares / sum_client_upload_shares * new_upload_speed) if active_torrent_count > 0 else new_upload_speed
+                    effective_download_speed = (torrent_client._client_config.upload_shares / sum_client_download_shares * new_download_speed) if active_torrent_count > 0 else new_download_speed
+                else: 
+                    effective_upload_speed = (active_torrent_count / sum_active_torrents * new_upload_speed) if active_torrent_count > 0 else new_upload_speed
+                    effective_download_speed = (active_torrent_count / sum_active_torrents * new_download_speed) if active_torrent_count > 0 else new_download_speed
                 try:
                     torrent_client.set_upload_speed(effective_upload_speed)
                     torrent_client.set_download_speed(effective_download_speed)


### PR DESCRIPTION
Hi,

This PR implements the feature requested in #26. I've introduced new configuration options with sensible default values to ensure backward compatibility, so existing installations won’t be broken by the change.

Please let me know if this approach doesn't align with your preferred way of adding new features.  I'm happy to adjust as needed.

Thanks!

Closes #26 